### PR TITLE
08 user login

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -1,28 +1,32 @@
 == README
 
-This README would normally document whatever steps are necessary to get the
-application up and running.
+##### Introduction
+TexArch is an online tool hosting data supportive to archaeological research of Sergio Ayala at Gault School of Archaeological Research in San Marcos, TX.
+The application introduces to the research, displays artifacts data and images and shows sites on a dynamic google map.
 
-Things you may want to cover:
-
-* Ruby version
+##### Getting started
 
 * System dependencies
+  * Rails ~> 4.2.6
+  * Ruby > 2.3.0
 
 * Configuration
+  * git clone git@github.com:Claudia108/TexArch.git
+  * cd TexArch
+  * bundle install
+  * to run the app locally: rails s
+  * visit http://localhost:3000/
 
-* Database creation
+* Database: postgresql
+  * access database: rails c
 
 * Database initialization
+  * rake db:reset
 
 * How to run the test suite
-
-* Services (job queues, cache servers, search engines, etc.)
+  * rake test
 
 * Deployment instructions
-
-* ...
-
-
-Please feel free to use a different markup language if you do not plan to run
-<tt>rake doc:app</tt>.
+  * Deployed app: https://texarch.herokuapp.com
+  * git push heroku master
+  * heroku run bundle exec rake db:migrate

--- a/README.rdoc
+++ b/README.rdoc
@@ -17,7 +17,7 @@ The application introduces to the research, displays artifacts data and images a
   * to run the app locally: rails s
   * visit http://localhost:3000/
 
-* Database: postgresql
+* Database: PostgreSQL
   * access database: rails c
 
 * Database initialization

--- a/app/assets/javascripts/map.js
+++ b/app/assets/javascripts/map.js
@@ -53,17 +53,22 @@ var initMap = function(response) {
         var infowindow = new google.maps.InfoWindow({
           content: contentString
         });
+
+        marker.addListener('mouseover', function () {
+          infowindow.open(map, marker);
+        });
+
         marker.addListener('click', function() {
           map.setZoom(10);
           map.setCenter(marker.getPosition());
           infowindow.open(map, marker);
         });
+
         google.maps.event.addListener(infowindow,'closeclick',function(){
           resetMap(map);
         });
-
       });
     }
-  }
+  };
   setMarkers(response);
-}
+};

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -109,6 +109,11 @@ table th {
   border: $main-border;
 }
 
+.site-image {
+  margin-top: 20px;
+  border: $main-border;
+}
+
 .index-height {
   height: 400px;
 }

--- a/app/controllers/admin/sites_controller.rb
+++ b/app/controllers/admin/sites_controller.rb
@@ -30,13 +30,6 @@ class Admin::SitesController < Admin::BaseController
     end
   end
 
-  # def destroy
-  #   site = Site.find(params[:id])
-  #   flash[:alert] = "Site and its Artifacts Deleted!"
-  #   site.destroy
-  #   redirect_to sites_path
-  # end
-
   private
 
   def site_params

--- a/app/controllers/admin/sites_controller.rb
+++ b/app/controllers/admin/sites_controller.rb
@@ -30,12 +30,12 @@ class Admin::SitesController < Admin::BaseController
     end
   end
 
-  def destroy
-    site = Site.find(params[:id])
-    flash[:alert] = "Site and its Artifacts Deleted!"
-    site.destroy
-    redirect_to sites_path
-  end
+  # def destroy
+  #   site = Site.find(params[:id])
+  #   flash[:alert] = "Site and its Artifacts Deleted!"
+  #   site.destroy
+  #   redirect_to sites_path
+  # end
 
   private
 

--- a/app/controllers/admin/sites_controller.rb
+++ b/app/controllers/admin/sites_controller.rb
@@ -33,7 +33,7 @@ class Admin::SitesController < Admin::BaseController
   private
 
   def site_params
-    params.require(:site).permit(:name, :longitude, :latitude, :site_type)
+    params.require(:site).permit(:name, :description, :trinominal, :longitude, :latitude, :site_type, :image)
   end
 
 end

--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -2,4 +2,5 @@ class Api::ApiController < ApplicationController
   protect_from_forgery with: :null_session
   respond_to :json, :xml
 
+  skip_before_action :store_location
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,7 +3,7 @@ class ApplicationController < ActionController::Base
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
 
-  before_filter :store_location
+  before_action :store_location
 
   helper_method :current_user,
                 :admin_authenticated,
@@ -23,13 +23,7 @@ class ApplicationController < ActionController::Base
   end
 
   def store_location
-    return unless request.get?
-    if (request.path != "/auth/google_oauth2" &&
-        request.path != "/auth/google_oauth2/callback" &&
-        request.path != "/logout" &&
-        !request.xhr?) # don't store ajax calls
-      session[:previous_url] = request.fullpath
-    end
+    session[:previous_url] = request.fullpath
   end
 
   def after_sign_in_path(current_user)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,8 @@ class ApplicationController < ActionController::Base
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
 
+  before_filter :store_location
+
   helper_method :current_user,
                 :admin_authenticated,
                 :require_user
@@ -18,5 +20,19 @@ class ApplicationController < ActionController::Base
 
   def require_user
     render file: '/public/404' unless current_user
+  end
+
+  def store_location
+    return unless request.get?
+    if (request.path != "/auth/google_oauth2" &&
+        request.path != "/auth/google_oauth2/callback" &&
+        request.path != "/logout" &&
+        !request.xhr?) # don't store ajax calls
+      session[:previous_url] = request.fullpath
+    end
+  end
+
+  def after_sign_in_path(current_user)
+    session[:previous_url] || root_path
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -26,7 +26,4 @@ class ApplicationController < ActionController::Base
     session[:previous_url] = request.fullpath
   end
 
-  def after_sign_in_path(current_user)
-    session[:previous_url] || root_path
-  end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,4 +1,6 @@
 class SessionsController < ApplicationController
+  skip_before_action :store_location
+
   def create
     if user = User.from_omniauth(request.env["omniauth.auth"])
       session[:user_id] = user.id

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -8,12 +8,18 @@ class SessionsController < ApplicationController
     if current_user.admin?
       redirect_to admin_dashboard_path
     else
-      redirect_to after_sign_in_path(current_user)
+      redirect_to after_sign_in_path
     end
   end
 
   def destroy
     session[:user_id] = {}
     redirect_to root_path
+  end
+
+  private
+
+  def after_sign_in_path
+    session[:previous_url] || root_path
   end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -6,7 +6,7 @@ class SessionsController < ApplicationController
     if current_user.admin?
       redirect_to admin_dashboard_path
     else
-      redirect_to request.referrer
+      redirect_to root_path
     end
   end
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -6,7 +6,7 @@ class SessionsController < ApplicationController
     if current_user.admin?
       redirect_to admin_dashboard_path
     else
-      redirect_to root_path
+      redirect_to after_sign_in_path(current_user)
     end
   end
 

--- a/app/models/artifact.rb
+++ b/app/models/artifact.rb
@@ -6,6 +6,7 @@ class Artifact < ActiveRecord::Base
       thumb: ["300x300>", :jpg]
     },
     default_url: "/images/landscape.jpg"
+
   validates_attachment_content_type :image, content_type: /\Aimage\/.*\Z/
 
   validates :point_type, presence: true

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -1,5 +1,5 @@
 class Site < ActiveRecord::Base
-  has_many :artifacts, dependent: :delete_all
+  has_many :artifacts#, dependent: :delete_all
 
   enum site_type: %w(public_site private_site)
 

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -1,8 +1,14 @@
 class Site < ActiveRecord::Base
   has_many :artifacts
+  has_attached_file :image, styles: {
+      medium: ["600x600>", :jpg],
+      thumb: ["300x300>", :jpg]
+    },
+    default_url: "/images/landscape.jpg"
 
   enum site_type: %w(public_site private_site)
 
+  validates_attachment_content_type :image, content_type: /\Aimage\/.*\Z/
   validates :longitude, presence: true
   validates :latitude, presence: true
   validates :name, presence: true

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -1,5 +1,5 @@
 class Site < ActiveRecord::Base
-  has_many :artifacts#, dependent: :delete_all
+  has_many :artifacts
 
   enum site_type: %w(public_site private_site)
 

--- a/app/views/admin/sites/_site_form.html.erb
+++ b/app/views/admin/sites/_site_form.html.erb
@@ -10,6 +10,16 @@
       </fieldset>
 
       <fieldset class="form-group col-md-6">
+        <%= f.label :trinominal %>
+        <%= f.text_field :trinominal, class: "form-control number" %>
+      </fieldset>
+
+      <fieldset class="form-group col-md-6">
+        <%= f.label :description %>
+        <%= f.text_field :description, class: "form-control number" %>
+      </fieldset>
+
+      <fieldset class="form-group col-md-6">
         <%= f.label :longitude %>
         <%= f.text_field :longitude, class: "form-control text", placeholder: "Input as decimal, like this: -97.70975" %>
       </fieldset>
@@ -17,6 +27,10 @@
       <fieldset class="form-group col-md-6">
         <%= f.label :latitude %>
         <%= f.text_field :latitude, class: "form-control", placeholder: "Input as decimal, like this: 30.89225" %>
+      </fieldset>
+
+      <fieldset class="form-group col-md-6">
+        <%= f.file_field :image, class: "form-control-file"%>
       </fieldset>
 
       <div class="c-input c-radio col-md-3 radio-button-line" id="radio1">

--- a/app/views/sites/show.html.erb
+++ b/app/views/sites/show.html.erb
@@ -29,7 +29,6 @@
         <tr>
           <td colspan=2>
             <%= link_to "Edit Site", edit_admin_site_path(@site.id), class: "btn btn-primary" %>
-            <!-- <#%= link_to "Delete Site", admin_site_path(@site.id), method: :delete, class: "btn btn-primary" %> -->
           </td>
         </tr>
       <% end %>

--- a/app/views/sites/show.html.erb
+++ b/app/views/sites/show.html.erb
@@ -1,38 +1,58 @@
 <h2> <%= @site.name %> </h2>
 
-<div class="col-md-6">
-  <table class="table table-striped col-md-6">
-    <thead>
-      <tr>
-        <th>Site Attributes</th>
-        <th>Coordinates</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td>Site Name</td>
-        <td><%= @site.name %></td>
-      </tr>
-      <tr>
-        <td>Longitude</td>
-        <td> <%= @site.longitude %></td>
-      </tr>
-      <tr>
-        <td>Latitude</td>
-        <td> <%= @site.latitude %></td>
-      </tr>
-      <tr>
-        <td>Site Type</td>
-        <td> <%= @site.site_type %></td>
-      </tr>
-      <% if admin_authenticated %>
+<div class="row">
+
+  <div class="col-md-5">
+    <table class="table table-striped">
+      <thead>
         <tr>
-          <td colspan=2>
-            <%= link_to "Edit Site", edit_admin_site_path(@site.id), class: "btn btn-primary" %>
-          </td>
+          <th colspan=2>Site Attributes</th>
+          <th></th>
         </tr>
-      <% end %>
-    </tbody>
-  </table>
-  <%= link_to "See Map for Location", map_path, class: "btn btn-primary" %>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Name</td>
+          <td><%= @site.name %></td>
+        </tr>
+        <tr>
+          <td>Trinominal</td>
+          <td><%= @site.trinominal %></td>
+        </tr>
+        <tr>
+          <td>Longitude</td>
+          <td> <%= @site.longitude %></td>
+        </tr>
+        <tr>
+          <td>Latitude</td>
+          <td> <%= @site.latitude %></td>
+        </tr>
+        <tr>
+          <td>Site Type</td>
+          <td> <%= @site.site_type %></td>
+        </tr>
+        <tr>
+          <td>Description</td>
+          <td><%= @site.description %></td>
+        </tr>
+
+        <% if admin_authenticated %>
+          <tr>
+            <td colspan=2>
+              <%= link_to "Edit Site", edit_admin_site_path(@site.id), class: "btn btn-primary" %>
+            </td>
+          </tr>
+        <% end %>
+
+      </tbody>
+    </table>
+    <%= link_to "See Map for Location", map_path, class: "btn btn-primary" %>
+  </div>
+
+  <div class="image-fluid img-rounded col-md-6">
+      <%= image_tag @site.image.url(:medium),
+        alt: "Site Image",
+        class: "img-rounded site-image" %>
+  </div>
+
 </div>

--- a/app/views/sites/show.html.erb
+++ b/app/views/sites/show.html.erb
@@ -29,7 +29,7 @@
         <tr>
           <td colspan=2>
             <%= link_to "Edit Site", edit_admin_site_path(@site.id), class: "btn btn-primary" %>
-            <%= link_to "Delete Site", admin_site_path(@site.id), method: :delete, class: "btn btn-primary" %>
+            <!-- <#%= link_to "Delete Site", admin_site_path(@site.id), method: :delete, class: "btn btn-primary" %> -->
           </td>
         </tr>
       <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,7 @@ Rails.application.routes.draw do
     resources :users, only: [:index]
 
     resources :artifacts, only: [:new, :create, :edit, :update, :destroy]
-    resources :sites, only: [:new, :create, :edit, :update, :destroy]
+    resources :sites, only: [:new, :create, :edit, :update]
   end
 
   resources :artifacts, only: [:show]

--- a/db/migrate/20160719201446_add_columns_to_site.rb
+++ b/db/migrate/20160719201446_add_columns_to_site.rb
@@ -1,0 +1,7 @@
+class AddColumnsToSite < ActiveRecord::Migration
+  def change
+    add_column :sites, :trinominal, :string
+    add_column :sites, :description, :string
+    add_attachment :sites, :image
+  end
+end

--- a/db/migrate/20160719221747_add_default_values_to_site.rb
+++ b/db/migrate/20160719221747_add_default_values_to_site.rb
@@ -1,0 +1,6 @@
+class AddDefaultValuesToSite < ActiveRecord::Migration
+  def change
+    change_column :sites, :description, :string, default: "no description available"
+    change_column :sites, :trinominal, :string, default: "no trinominal available"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160610232228) do
+ActiveRecord::Schema.define(version: 20160719221747) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -37,10 +37,16 @@ ActiveRecord::Schema.define(version: 20160610232228) do
   create_table "sites", force: :cascade do |t|
     t.string   "longitude"
     t.string   "latitude"
-    t.datetime "created_at",             null: false
-    t.datetime "updated_at",             null: false
-    t.integer  "site_type",  default: 0
+    t.datetime "created_at",                                              null: false
+    t.datetime "updated_at",                                              null: false
+    t.integer  "site_type",          default: 0
     t.string   "name"
+    t.string   "trinominal",         default: "no trinominal available"
+    t.string   "description",        default: "no description available"
+    t.string   "image_file_name"
+    t.string   "image_content_type"
+    t.integer  "image_file_size"
+    t.datetime "image_updated_at"
   end
 
   create_table "users", force: :cascade do |t|

--- a/test/fixtures/sites.yml
+++ b/test/fixtures/sites.yml
@@ -4,16 +4,34 @@ one:
   longitude: -97.70975
   latitude: 30.89225
   name: Gault Site
+  trinominal: WVF123
+  description: This site is located in N-Texas.
+  image_file_name: landscape.jpg
+  image_content_type: image/jpg
+  image_file_size: 1273812
+  image_updated_at: 2016-06-14 20:02:06
   site_type: 0
 
 two:
   longitude: 39.50
   latitude: -98.35
   name: Center US
+  trinominal: XYZ123
+  description: Explore the center of the US.
+  image_file_name: landscape.jpg
+  image_content_type: image/jpg
+  image_file_size: 1273812
+  image_updated_at: 2016-06-14 20:02:06
   site_type: 1
 
 three:
   longitude: -104.9847000
   latitude: 39.7391500
   name: Denver
+  trinominal: ABC123
+  description: This site is is a lot of fun.
+  image_file_name: landscape.jpg
+  image_content_type: image/jpg
+  image_file_size: 1273812
+  image_updated_at: 2016-06-14 20:02:06
   site_type: 1

--- a/test/integration/admin_site_creation_test.rb
+++ b/test/integration/admin_site_creation_test.rb
@@ -16,6 +16,76 @@ class AdminSiteCreationTest < ActionDispatch::IntegrationTest
     assert_equal new_admin_site_path, current_path
 
     fill_in "site[name]", with: "Denver Site"
+    fill_in "site[trinominal]", with: "XCF123"
+    fill_in "site[description]", with: "Visit a fun city!"
+    fill_in "site[longitude]", with: "-104.991531"
+    fill_in "site[latitude]", with: "39.742043"
+    attach_file("site[image]", 'app/assets/images/landscape.jpg')
+    find(:css, "#radio1").set(true)
+
+    click_button("Add Site")
+
+    assert_equal site_path(Site.last.id), current_path
+    assert page.has_content?("#{Site.last.name} Created!")
+    assert page.has_content?("Name")
+    assert page.has_content?("Denver Site")
+    assert page.has_content?("public_site")
+    assert page.has_content?("Visit a fun city!")
+    assert page.has_content?("XCF123")
+    assert page.has_css?("img[src*='landscape.jpg']")
+  end
+
+  test "returns error if name is missing" do
+    admin = admin_login
+
+    assert_equal '/admin/dashboard', current_path
+    assert page.has_content?("#{admin.first_name}, welcome to your dashboard")
+    assert page.has_link?("Add a new Site")
+
+    click_link("Add a new Site")
+    assert_equal new_admin_site_path, current_path
+
+    fill_in "site[longitude]", with: "-104.991531"
+    fill_in "site[latitude]", with: "39.742043"
+    find(:css, "#radio1").set(true)
+
+    click_button("Add Site")
+
+    assert_equal new_admin_site_path, current_path
+    assert page.has_content?("Data is missing or invalid! Try again")
+  end
+
+  test "returns error if longitude or latitude is missing" do
+    admin = admin_login
+
+    assert_equal '/admin/dashboard', current_path
+    assert page.has_content?("#{admin.first_name}, welcome to your dashboard")
+    assert page.has_link?("Add a new Site")
+
+    click_link("Add a new Site")
+    assert_equal new_admin_site_path, current_path
+
+    fill_in "site[name]", with: "Denver Site"
+    fill_in "site[latitude]", with: "39.742043"
+    find(:css, "#radio1").set(true)
+
+    click_button("Add Site")
+
+    assert_equal new_admin_site_path, current_path
+    assert page.has_content?("Data is missing or invalid! Try again")
+  end
+
+  test "returns default values if trinominal or description is missing" do
+    admin = admin_login
+
+    assert_equal '/admin/dashboard', current_path
+    assert page.has_content?("#{admin.first_name}, welcome to your dashboard")
+    assert page.has_link?("Add a new Site")
+
+    click_link("Add a new Site")
+    assert_equal new_admin_site_path, current_path
+
+    fill_in "site[name]", with: "Denver Site"
     fill_in "site[longitude]", with: "-104.991531"
     fill_in "site[latitude]", with: "39.742043"
     find(:css, "#radio1").set(true)
@@ -24,49 +94,11 @@ class AdminSiteCreationTest < ActionDispatch::IntegrationTest
 
     assert_equal site_path(Site.last.id), current_path
     assert page.has_content?("#{Site.last.name} Created!")
-    assert page.has_content?("Site Name")
+    assert page.has_content?("Name")
     assert page.has_content?("Denver Site")
     assert page.has_content?("public_site")
-  end
-
-  test "returns error if attribute is missing" do
-    admin = admin_login
-
-    assert_equal '/admin/dashboard', current_path
-    assert page.has_content?("#{admin.first_name}, welcome to your dashboard")
-    assert page.has_link?("Add a new Site")
-
-    click_link("Add a new Site")
-    assert_equal new_admin_site_path, current_path
-
-    fill_in "site[longitude]", with: "-104.991531"
-    fill_in "site[latitude]", with: "39.742043"
-    find(:css, "#radio1").set(true)
-
-    click_button("Add Site")
-
-    assert_equal new_admin_site_path, current_path
-    assert page.has_content?("Data is missing or invalid! Try again")
-  end
-
-  test "returns error if attribute format is incorrect" do
-    admin = admin_login
-
-    assert_equal '/admin/dashboard', current_path
-    assert page.has_content?("#{admin.first_name}, welcome to your dashboard")
-    assert page.has_link?("Add a new Site")
-
-    click_link("Add a new Site")
-    assert_equal new_admin_site_path, current_path
-
-    fill_in "site[longitude]", with: "Milky Way"
-    fill_in "site[latitude]", with: "39.742043"
-    find(:css, "#radio1").set(true)
-
-    click_button("Add Site")
-
-    assert_equal new_admin_site_path, current_path
-    assert page.has_content?("Data is missing or invalid! Try again")
+    assert page.has_content?("no description available")
+    assert page.has_content?("no trinominal available")
   end
 
   test "updating a site" do

--- a/test/integration/admin_site_creation_test.rb
+++ b/test/integration/admin_site_creation_test.rb
@@ -121,26 +121,20 @@ class AdminSiteCreationTest < ActionDispatch::IntegrationTest
     assert page.has_content?("Data is missing or invalid! Try again")
   end
 
-  # test "deleting a site" do
-  #   admin = admin_login
-  #   site = Site.first
-  #
-  #   assert_equal '/admin/dashboard', current_path
-  #   click_link("Sites")
-  #   assert_equal sites_path, current_path
-  #
-  #   click_link(site.name)
-  #   assert_equal site_path(site.id), current_path
-  #   assert page.has_content?(site.name)
-  #   assert page.has_content?(site.longitude)
-  #   assert page.has_content?(site.latitude)
-  #
-  #   click_link("Delete")
-  #   assert_equal sites_path, current_path
-  #   assert page.has_content?("Site and its Artifacts Deleted!")
-  #
-  #   refute page.has_content?(site.name)
-  #   refute page.has_content?(site.longitude)
-  #   refute page.has_content?(site.latitude)
-  # end
+  test "admin cannot delete a site" do
+    admin = admin_login
+    site = Site.first
+
+    assert_equal '/admin/dashboard', current_path
+    click_link("Sites")
+    assert_equal sites_path, current_path
+
+    click_link(site.name)
+    assert_equal site_path(site.id), current_path
+    assert page.has_content?(site.name)
+    assert page.has_content?(site.longitude)
+    assert page.has_content?(site.latitude)
+
+    refute page.has_link?("Delete")
+  end
 end

--- a/test/integration/admin_site_creation_test.rb
+++ b/test/integration/admin_site_creation_test.rb
@@ -121,26 +121,26 @@ class AdminSiteCreationTest < ActionDispatch::IntegrationTest
     assert page.has_content?("Data is missing or invalid! Try again")
   end
 
-  test "deleting a site" do
-    admin = admin_login
-    site = Site.first
-
-    assert_equal '/admin/dashboard', current_path
-    click_link("Sites")
-    assert_equal sites_path, current_path
-
-    click_link(site.name)
-    assert_equal site_path(site.id), current_path
-    assert page.has_content?(site.name)
-    assert page.has_content?(site.longitude)
-    assert page.has_content?(site.latitude)
-
-    click_link("Delete")
-    assert_equal sites_path, current_path
-    assert page.has_content?("Site and its Artifacts Deleted!")
-
-    refute page.has_content?(site.name)
-    refute page.has_content?(site.longitude)
-    refute page.has_content?(site.latitude)
-  end
+  # test "deleting a site" do
+  #   admin = admin_login
+  #   site = Site.first
+  #
+  #   assert_equal '/admin/dashboard', current_path
+  #   click_link("Sites")
+  #   assert_equal sites_path, current_path
+  #
+  #   click_link(site.name)
+  #   assert_equal site_path(site.id), current_path
+  #   assert page.has_content?(site.name)
+  #   assert page.has_content?(site.longitude)
+  #   assert page.has_content?(site.latitude)
+  #
+  #   click_link("Delete")
+  #   assert_equal sites_path, current_path
+  #   assert page.has_content?("Site and its Artifacts Deleted!")
+  #
+  #   refute page.has_content?(site.name)
+  #   refute page.has_content?(site.longitude)
+  #   refute page.has_content?(site.latitude)
+  # end
 end

--- a/test/integration/user_login_test.rb
+++ b/test/integration/user_login_test.rb
@@ -15,6 +15,30 @@ class UserLoginTest < ActionDispatch::IntegrationTest
     assert page.has_link?("Logout")
   end
 
+  test "after login user is redirected to calf_creek_horizon page" do
+    visit '/calf_creek_horizon'
+    assert_equal 200, page.status_code
+    click_link "Sign in with Google"
+    assert_equal "/calf_creek_horizon", current_path
+    assert page.has_content?("Claudia")
+  end
+
+  test "after login user is redirected to info page" do
+    visit '/info'
+    assert_equal 200, page.status_code
+    click_link "Sign in with Google"
+    assert_equal "/info", current_path
+    assert page.has_content?("Claudia")
+  end
+
+  test "after login user is redirected to info/preform page" do
+    visit '/info/preforms'
+    assert_equal 200, page.status_code
+    click_link "Sign in with Google"
+    assert_equal "/info/preforms", current_path
+    assert page.has_content?("Claudia")
+  end
+
   test "logging out" do
     visit '/'
     click_link "Sign in with Google"
@@ -27,5 +51,4 @@ class UserLoginTest < ActionDispatch::IntegrationTest
     refute page.has_content?("Logout")
     assert page.has_content?("Sign in with Google")
   end
-
 end

--- a/test/integration/user_views_sites_test.rb
+++ b/test/integration/user_views_sites_test.rb
@@ -29,8 +29,11 @@ class UserLoginTest < ActionDispatch::IntegrationTest
 
     assert_equal site_path(site.id), current_path
     assert page.has_content?(site.name)
+    assert page.has_content?(site.trinominal)
+    assert page.has_content?(site.description)
     assert page.has_content?(site.longitude)
     assert page.has_content?(site.latitude)
     assert page.has_content?(site.site_type)
+    assert page.has_css?("img[src*='landscape.jpg']")
   end
 end


### PR DESCRIPTION
Updates the following features:
1. Add README
2. Fix user login path (the original redirect_to request.referrer interfered with google-oauth and broke the site):
ApplicationController: create before_filter and after_sign_in_path(current_user).
SessionsController: use redirect_to  after_sign_in_path(current_user).
1. Remove delete feature for sites - per client request
2. Admin/SitesController: remove destroy action
3. views/sites/show: remove delete button
4. routes: admin/sites: remove destroy action
5. test/admin_site_creation_test.rb: update last test to mirror that admin cannot delete sites anymore.
6. Add attributes to sites - per client request
7. Add migration to add columns :trinominal and :description and to add attachment :image - as optional attributes.
8. Add migration to add default values to :trinominal and :description if non are given.
9. Update views/admin/sites/_site_form.html.erb and views/sites/show.html.erb with added attributes.
10. Update admin_site_creation_test.rb and user_views_sites_test.rb to reflect changes in schema.
11. Update map.js with mouseover function
12. Add mouseover eventListener to map.js so users can view the name of the site before clicking on it.
